### PR TITLE
Add copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2024 SmartKids LLC
 Copyright (c) 2022 just-the-docs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
At the moment, the only copyright notice in this repo says “Copyright (c) 2022 just-the-docs”. This PR adds another notice for SmartKids LLC.